### PR TITLE
Parse release entries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,10 @@ version = "0.1.0"
 authors = ["Paul Betts <paul@paulbetts.org>"]
 
 [dependencies]
+env_logger = "0.3"
+lazy_static = "0.2"
+log = "0.3"
+regex = "0.2"
 semver = "0.7.0"
 sha2 = "0.6.0"
+url = "1.5.1"

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -1,0 +1,119 @@
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Hex binary-to-text encoding
+
+pub use self::FromHexError::*;
+
+use std::fmt;
+use std::error;
+
+/// A trait for converting a value to hexadecimal encoding
+pub trait ToHex {
+    /// Converts the value of `self` to a hex value, returning the owned
+    /// string.
+    fn to_hex(&self) -> String;
+}
+
+const CHARS: &'static [u8] = b"0123456789abcdef";
+
+impl ToHex for [u8] {
+    /// Turn a vector of `u8` bytes into a hexadecimal string.
+    fn to_hex(&self) -> String {
+        let mut v = Vec::with_capacity(self.len() * 2);
+        for &byte in self {
+            v.push(CHARS[(byte >> 4) as usize]);
+            v.push(CHARS[(byte & 0xf) as usize]);
+        }
+
+        unsafe {
+            String::from_utf8_unchecked(v)
+        }
+    }
+}
+
+/// A trait for converting hexadecimal encoded values
+pub trait FromHex {
+    /// Converts the value of `self`, interpreted as hexadecimal encoded data,
+    /// into an owned vector of bytes, returning the vector.
+    fn from_hex(&self) -> Result<Vec<u8>, FromHexError>;
+}
+
+/// Errors that can occur when decoding a hex encoded string
+#[derive(Copy, Clone, Debug)]
+pub enum FromHexError {
+    /// The input contained a character not part of the hex format
+    InvalidHexCharacter(char, usize),
+    /// The input had an invalid length
+    InvalidHexLength,
+}
+
+impl fmt::Display for FromHexError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            InvalidHexCharacter(ch, idx) =>
+                write!(f, "Invalid character '{}' at position {}", ch, idx),
+            InvalidHexLength => write!(f, "Invalid input length"),
+        }
+    }
+}
+
+impl error::Error for FromHexError {
+    fn description(&self) -> &str {
+        match *self {
+            InvalidHexCharacter(..) => "invalid character",
+            InvalidHexLength => "invalid length",
+        }
+    }
+}
+
+
+impl FromHex for str {
+    /// Convert any hexadecimal encoded string (literal, `@`, `&`, or `~`)
+    /// to the byte values it encodes.
+    ///
+    /// You can use the `String::from_utf8` function to turn a
+    /// `Vec<u8>` into a string with characters corresponding to those values.
+    fn from_hex(&self) -> Result<Vec<u8>, FromHexError> {
+        // This may be an overestimate if there is any whitespace
+        let mut b = Vec::with_capacity(self.len() / 2);
+        let mut modulus = 0;
+        let mut buf = 0;
+
+        for (idx, byte) in self.bytes().enumerate() {
+            buf <<= 4;
+
+            match byte {
+                b'A'...b'F' => buf |= byte - b'A' + 10,
+                b'a'...b'f' => buf |= byte - b'a' + 10,
+                b'0'...b'9' => buf |= byte - b'0',
+                b' '|b'\r'|b'\n'|b'\t' => {
+                    buf >>= 4;
+                    continue
+                }
+                _ => {
+                    let ch = self[idx..].chars().next().unwrap();
+                    return Err(InvalidHexCharacter(ch, idx))
+                }
+            }
+
+            modulus += 1;
+            if modulus == 2 {
+                modulus = 0;
+                b.push(buf);
+            }
+        }
+
+        match modulus {
+            0 => Ok(b.into_iter().collect()),
+            _ => Err(InvalidHexLength),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ extern crate log;
 extern crate regex;
 extern crate semver;
 extern crate sha2;
+extern crate url;
 
 pub use release_entry::{ReleaseEntry};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,19 @@
 //#![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]
 
+#[macro_use]
+extern crate lazy_static;
+
+/*
+#[macro_use]
+extern crate log;
+*/
+
+extern crate regex;
 extern crate semver;
 extern crate sha2;
 
 pub use release_entry::{ReleaseEntry};
 
+mod hex;
 mod release_entry;

--- a/src/release_entry.rs
+++ b/src/release_entry.rs
@@ -1,35 +1,67 @@
+use std::error::{Error};
+use regex::*;
+use hex::*;
+
+/* Example lines:
+
+# SHA256 of the file                                             Name       Version Size  [delta/full] release%
+e4548fba3f902e63e3fff36db7cbbd1837493e21c51f0751e51ee1483ddd0f35 myproject.7z 1.2.3 12345 full
+a4548fba3f902e63e3fff36db7cbbd1837493e21c51f0751e51ee1483ddd0f35 myproject-delta.7z 123 delta
+b4548fba3f902e63e3fff36db7cbbd1837493e21c51f0751e51ee1483ddd0f35 myproject-beta.7z 34567 full 5%
+*/
+
 #[derive(Debug)]
 pub struct ReleaseEntry {
-  pub is_delta: bool,
   pub sha256: [u8; 32],
+  pub filename_or_url: String,
   pub length: i64,
+  pub is_delta: bool,
+  pub percentage: i64,
 }
 
 impl Default for ReleaseEntry {
   fn default() -> ReleaseEntry {
     ReleaseEntry {
+      filename_or_url: "Foobar".to_owned(),
       is_delta: true,
       length: 42,
       sha256: [0; 32],
+      percentage: 100,
     }
   }
 }
 
+lazy_static! {
+  static ref SHA256: Regex = Regex::new(r"^[A-Fa-f0-9]{64}$").unwrap();
+}
+
 impl ReleaseEntry {
-  /*
-  fn parse(entry: &str) -> Self {
-    let mut ret = ReleaseEntry {
-      is_delta: false,
-      length: 5,
-    };
+  fn parse_sha256(sha256: &str, to_fill: &mut ReleaseEntry) -> Result<bool, Box<Error>> {
+    if SHA256.is_match(sha256) == false {
+      return Err(From::from("SHA256 is malformed"));
+    }
+
+    let ret = try!(sha256.from_hex());
+    if ret.len() != 32 {
+      return Err(From::from("SHA256 is malformed"));
+    }
+
+    for i in 0..32 { to_fill.sha256[i] = ret[i]; }
+    return Ok(true);
   }
 
-  fn parse(entry: &str) -> Self {
+  pub fn parse(entry: &str) -> Result<Self, Box<Error>> {
+    let mut ret = ReleaseEntry::default();
+    let entries = entry.split_whitespace().collect::<Vec<&str>>();
+
+    try!(ReleaseEntry::parse_sha256(entries[0], &mut ret));
+    return Ok(ret);
   }
 
+/*
   fn parse_file(file: &str) -> Vec<ReleaseEntry> {
   }
-  */
+ */
 }
 
 #[cfg(test)]
@@ -40,7 +72,7 @@ mod tests {
 
   fn print_result(sum: &[u8], name: &str) {
     for byte in sum {
-        print!("{:02x}", byte);
+      print!("{:02x}", byte);
     }
     println!("\t{}", name);
   }
@@ -49,6 +81,28 @@ mod tests {
   fn create_a_release_entry() {
     let f = ReleaseEntry::default();
     assert_eq!(f.length, 42);
+  }
+
+  #[test]
+  fn parse_should_read_valid_sha256() {
+    let input = "e4548fba3f902e63e3fff36db7cbbd1837493e21c51f0751e51ee1483ddd0f35 myproject.7z 12345 full";
+    let result = ReleaseEntry::parse(input).unwrap();
+
+    assert_eq!(result.sha256[0], 0xE4);
+    assert_eq!(result.sha256[1], 0x54);
+    assert_eq!(result.sha256[31], 0x35);
+  }
+
+  #[test]
+  fn parse_should_fail_invalid_sha256() {
+    let input = "48fba3f902e63e3fff36db7cbbd1837493e21c51f0751e51ee1483ddd0f35 myproject.7z 12345 full";
+    ReleaseEntry::parse(input).unwrap_err();
+  }
+
+  #[test]
+  fn parse_should_fail_very_invalid_sha256() {
+    let input = "48Z myproject.7z 12345 full";
+    ReleaseEntry::parse(input).unwrap_err();
   }
 
   #[test]

--- a/src/release_entry.rs
+++ b/src/release_entry.rs
@@ -1,6 +1,8 @@
-use std::error::{Error};
-use regex::*;
 use hex::*;
+use regex::Regex;
+use semver::Version;
+use std::error::{Error};
+use url::{Url};
 
 /* Example lines:
 
@@ -14,15 +16,17 @@ b4548fba3f902e63e3fff36db7cbbd1837493e21c51f0751e51ee1483ddd0f35 myproject-beta.
 pub struct ReleaseEntry {
   pub sha256: [u8; 32],
   pub filename_or_url: String,
+  pub version: Version,
   pub length: i64,
   pub is_delta: bool,
-  pub percentage: i64,
+  pub percentage: i32,
 }
 
 impl Default for ReleaseEntry {
   fn default() -> ReleaseEntry {
     ReleaseEntry {
-      filename_or_url: "Foobar".to_owned(),
+      filename_or_url: "Foobdar".to_owned(),
+      version: Version::parse("1.0.0").unwrap(),
       is_delta: true,
       length: 42,
       sha256: [0; 32],
@@ -32,15 +36,15 @@ impl Default for ReleaseEntry {
 }
 
 lazy_static! {
-  static ref SHA256: Regex = Regex::new(r"^[A-Fa-f0-9]{64}$").unwrap();
+  static ref SCHEME: Regex = Regex::new(r"^https:").unwrap();
+}
+
+lazy_static! {
+  static ref COMMENT: Regex = Regex::new(r"#.*$").unwrap();
 }
 
 impl ReleaseEntry {
   fn parse_sha256(sha256: &str, to_fill: &mut ReleaseEntry) -> Result<bool, Box<Error>> {
-    if SHA256.is_match(sha256) == false {
-      return Err(From::from("SHA256 is malformed"));
-    }
-
     let ret = try!(sha256.from_hex());
     if ret.len() != 32 {
       return Err(From::from("SHA256 is malformed"));
@@ -50,12 +54,68 @@ impl ReleaseEntry {
     return Ok(true);
   }
 
-  pub fn parse(entry: &str) -> Result<Self, Box<Error>> {
-    let mut ret = ReleaseEntry::default();
-    let entries = entry.split_whitespace().collect::<Vec<&str>>();
+  fn parse_delta_full(delta_or_full: &str) -> Result<bool, Box<Error>> {
+    match delta_or_full {
+      "delta" => Ok(true),
+      "full" => Ok(false),
+      _ => Err(From::from("Package type must be either 'delta' or 'full'"))
+    }
+  }
 
-    try!(ReleaseEntry::parse_sha256(entries[0], &mut ret));
-    return Ok(ret);
+  fn parse_name(filename_or_url: &str) -> Result<&str, Box<Error>> {
+    if SCHEME.is_match(filename_or_url) {
+      try!(Url::parse(filename_or_url));
+      return Ok(filename_or_url)
+    } else {
+      let u = format!("file://{}", filename_or_url);
+      try!(Url::parse(&u));
+      return Ok(filename_or_url);
+    }
+  }
+
+  fn parse_percentage(percent: &str) -> Result<i32, Box<Error>> {
+    let n = try!(percent.trim_right_matches("%").parse::<i32>());
+    if n > 100 || n < 0 {
+      return Err(From::from("Percentage must be between 0 and 100 inclusive"));
+    }
+
+    return Ok(n);
+  }
+
+  pub fn parse(entry: &str) -> Result<Self, Box<Error>> {
+    let e = entry.split_whitespace().collect::<Vec<_>>();
+
+    return match e.len() {
+      5 => {
+        let (sha256, name, version, size, delta_or_full) = (e[0], e[1], e[2], e[3], e[4]);
+        let mut ret = ReleaseEntry {
+          sha256: [0; 32],
+          is_delta: try!(ReleaseEntry::parse_delta_full(delta_or_full)),
+          filename_or_url: try!(ReleaseEntry::parse_name(name)).to_owned(),
+          version: try!(Version::parse(version)),
+          length: try!(size.parse::<i64>()),
+          percentage: 100,
+        };
+
+        try!(ReleaseEntry::parse_sha256(sha256, &mut ret));
+        return Ok(ret);
+      },
+      6 => {
+        let (sha256, name, version, size, delta_or_full, percent) = (e[0], e[1], e[2], e[3], e[4], e[5]);
+        let mut ret = ReleaseEntry {
+          sha256: [0; 32],
+          is_delta: try!(ReleaseEntry::parse_delta_full(delta_or_full)),
+          filename_or_url: try!(ReleaseEntry::parse_name(name)).to_owned(),
+          version: try!(Version::parse(version)),
+          length: try!(size.parse::<i64>()),
+          percentage: try!(ReleaseEntry::parse_percentage(percent))
+        };
+
+        try!(ReleaseEntry::parse_sha256(sha256, &mut ret));
+        return Ok(ret);
+      },
+      _ => Err(From::from("Invalid Release Entry string"))
+    }
   }
 
 /*
@@ -68,6 +128,7 @@ impl ReleaseEntry {
 mod tests {
   use sha2::Sha256;
   use sha2::Digest;
+  use url::{Url};
   use super::ReleaseEntry;
 
   fn print_result(sum: &[u8], name: &str) {
@@ -85,7 +146,7 @@ mod tests {
 
   #[test]
   fn parse_should_read_valid_sha256() {
-    let input = "e4548fba3f902e63e3fff36db7cbbd1837493e21c51f0751e51ee1483ddd0f35 myproject.7z 12345 full";
+    let input = "e4548fba3f902e63e3fff36db7cbbd1837493e21c51f0751e51ee1483ddd0f35 myproject.7z 1.2.3 12345 full";
     let result = ReleaseEntry::parse(input).unwrap();
 
     assert_eq!(result.sha256[0], 0xE4);
@@ -95,13 +156,51 @@ mod tests {
 
   #[test]
   fn parse_should_fail_invalid_sha256() {
-    let input = "48fba3f902e63e3fff36db7cbbd1837493e21c51f0751e51ee1483ddd0f35 myproject.7z 12345 full";
+    let input = "48fba3f902e63e3fff36db7cbbd1837493e21c51f0751e51ee1483ddd0f35 myproject.7z 1.2.3 12345 full";
     ReleaseEntry::parse(input).unwrap_err();
   }
 
   #[test]
   fn parse_should_fail_very_invalid_sha256() {
     let input = "48Z myproject.7z 12345 full";
+    ReleaseEntry::parse(input).unwrap_err();
+  }
+
+  #[test]
+  fn parse_should_fail_invalid_type() {
+    let input = "48fba3f902e63e3fff36db7cbbd1837493e21c51f0751e51ee1483ddd0f35 myproject.7z 1.2.3 12345 foobar";
+    ReleaseEntry::parse(input).unwrap_err();
+  }
+
+  #[test]
+  fn parse_should_set_delta_package() {
+    let input = "e4548fba3f902e63e3fff36db7cbbd1837493e21c51f0751e51ee1483ddd0f35 myproject.7z 1.2.3 12345 delta";
+    let result = ReleaseEntry::parse(input).unwrap();
+
+    assert_eq!(result.is_delta, true);
+
+    let input2 = "e4548fba3f902e63e3fff36db7cbbd1837493e21c51f0751e51ee1483ddd0f35 myproject.7z 1.2.3 12345 full";
+    let result2 = ReleaseEntry::parse(input2).unwrap();
+
+    assert_eq!(result2.is_delta, false);
+  }
+
+  #[test]
+  fn parse_should_accept_percentages() {
+    let input = "e4548fba3f902e63e3fff36db7cbbd1837493e21c51f0751e51ee1483ddd0f35 myproject.7z 1.2.3 12345 delta 45%";
+    let result = ReleaseEntry::parse(input).unwrap();
+    assert_eq!(result.percentage, 45);
+  }
+
+  #[test]
+  fn parse_should_fail_giant_percentages() {
+    let input = "e4548fba3f902e63e3fff36db7cbbd1837493e21c51f0751e51ee1483ddd0f35 myproject.7z 1.2.3 12345 delta 145%";
+    ReleaseEntry::parse(input).unwrap_err();
+  }
+
+  #[test]
+  fn parse_should_fail_negative_percentages() {
+    let input = "e4548fba3f902e63e3fff36db7cbbd1837493e21c51f0751e51ee1483ddd0f35 myproject.7z 1.2.3 12345 delta -145%";
     ReleaseEntry::parse(input).unwrap_err();
   }
 


### PR DESCRIPTION
This PR starts off the basics of parsing a RELEASES file. RELEASES files are similar to Squirrel.Windows's RELEASES file format, with a few key differences:

```
# Comments begin with a hash
# SHA256 of the file                                             Name       Version Size  [delta/full] release%
e4548fba3f902e63e3fff36db7cbbd1837493e21c51f0751e51ee1483ddd0f35 myproject.7z 1.2.3 12345 full
a4548fba3f902e63e3fff36db7cbbd1837493e21c51f0751e51ee1483ddd0f35 myproject-delta.7z 123 delta
b4548fba3f902e63e3fff36db7cbbd1837493e21c51f0751e51ee1483ddd0f35 https://beta-updates.somewebsite.com/myproject-beta.7z 34567 full 5%
```

Here's what's new:

* SHA256 is now used instead of SHA1
* Filenames no longer have any special parsing, they can now be any HTTPS URL or URL-encoded filename (i.e. if you want to ship "My Cool Project.7z", it needs to be "My%20Cool%20Project.7z").
* Delta/full and the version are now separate fields